### PR TITLE
ssl/t1_enc: Fix kTLS RX offload path

### DIFF
--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -105,7 +105,7 @@ static int count_unprocessed_records(SSL *s)
             return -1;
 
         /* Read until next record */
-        if (PACKET_get_length_prefixed_2(&pkt, &subpkt))
+        if (!PACKET_get_length_prefixed_2(&pkt, &subpkt))
             return -1;
 
         count += 1;


### PR DESCRIPTION
During counting of the unprocessed records, return code is treated in a
wrong way. This forces kTLS RX path to be skipped in case of presence
of unprocessed records.

[ Upstream commit d73a7a3a71270aaadb4e4e678ae9bd3cef8b9cbd ]